### PR TITLE
fix loading audio in memory from a ctypes pointer on MacOS

### DIFF
--- a/sound_lib/stream.py
+++ b/sound_lib/stream.py
@@ -91,7 +91,7 @@ class FileStream(BaseStream):
         decode=False,
         unicode=True,
     ):
-        if platform.system() == "Darwin" and file:
+        if platform.system() == "Darwin" and file and not mem:
             unicode = False
             file = file.encode(sys.getfilesystemencoding())
         self.setup_flag_mapping()


### PR DESCRIPTION
On MacOS, the file argument passed to the constructor of the FileStream class always had .encode() called on it, even if mem was True meaning that file was something like a ctypes pointer which doesn't have an encode method.

This simply adds a `and not mem` condition to the code block where the file argument was encoded, so that .encode will no longer be called on a ctypes pointer resulting in a traceback when loading audio data from memory on MacOS.